### PR TITLE
Changed Base URL to be HTTPS

### DIFF
--- a/deezer.go
+++ b/deezer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmcvetta/napping"
 )
 
-var BaseUrl = "http://api.deezer.com"
+var BaseUrl = "https://api.deezer.com"
 
 func listParams(index, limit int) *url.Values {
 	v := &url.Values{}


### PR DESCRIPTION
## Motivation

I was developing my API on a public network so this library failed to connect to the Deezer API. This should be using HTTPS anyway for security and privacy reasons.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by author

## Progress

- [x] Finished task